### PR TITLE
Fix re-rendering of suggested accounts on Instagram (Issue #1 )

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,23 +1,35 @@
-recommendedIsRemoved = false;
-function removeContent() {
+function getRecommendedElement() {
   const father =
-    document.body.childNodes[1]?.childNodes[0]?.childNodes[0]?.childNodes[1]
+    document.body?.childNodes[1]?.childNodes[0]?.childNodes[0]?.childNodes[1]
       ?.childNodes[0]?.firstChild?.firstChild?.firstChild?.firstChild;
   if (!father) return;
-  const sidebar = father.childNodes[0];
-  const main = father.childNodes[1].firstChild.firstChild.firstChild;
-  const recommended = main?.childNodes[1]?.firstChild.childNodes[1];
-  if (recommended) {
-    removeRecommendedElement(recommended);
+  const main = father?.childNodes[1]?.firstChild?.firstChild?.firstChild;
+  const recommendedElement = main?.childNodes[1]?.firstChild?.childNodes[1];
+  return recommendedElement;
+}
+
+function removeContent() {
+  const recommendedElement = getRecommendedElement();
+
+  if (recommendedElement) {
+    recommendedElement.style.display = "none";
+    recommendedElement.previousSibling.style.margin = "1.25rem 0";
   }
 }
 
-const removeRecommendedElement = (recommendedElement) => {
-  if (recommendedIsRemoved) return;
-  recommendedElement.remove();
-  recommendedIsRemoved = true;
-};
+function observeDOM() {
+  const targetNode = document.querySelector("body");
+  const config = { childList: true, subtree: true };
+
+  const callback = function (mutationsList, observer) {
+    removeContent();
+  };
+
+  const observer = new MutationObserver(callback);
+
+  observer.observe(targetNode, config);
+}
 
 window.addEventListener("load", () => {
-  removeContent();
+  observeDOM();
 });


### PR DESCRIPTION
This PR addresses and resolves Issue #1 , where suggested accounts would reappear after a user exits from viewing a story on Instagram. The proposed changes refactor the content removal logic and ensure consistent behavior through the introduction of a DOM observer.

### Key Changes:
- Isolated the recommended element selection logic into `getRecommendedElement()` function to improve code clarity and maintenance.
- Switched to using `display: none` for hiding the recommended content, avoiding the complete removal of the element which can cause re-rendering issues.
- Implemented `observeDOM()`, a function that employs a `MutationObserver` to monitor changes in the DOM and reapply content hiding logic to tackle the dynamic nature of Instagram's content updates.
- Modified the styling adjustment logic to use responsive units (`rem`) to dynamically adjust margins based on the device.

### Impact:
- These changes maintain the expected behavior of the extension by ensuring the suggested content remains hidden even after navigating Instagram's dynamic interface, specifically after viewing and exiting stories.
- By improving the resilience of the content hiding feature, the extension provides a more consistent user experience in line with the expected behavior outlined in Issue #1 .

### Testing Conducted:
- Manual testing confirms that the suggested accounts stay hidden during navigation and after exiting story views.
- Further testing across various devices and screen sizes is recommended to validate the responsive design adjustments.

Resolves #1 
